### PR TITLE
scikit-rf 1.8.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,62 +1,74 @@
-{% set version = "1.2.0" %}
-{% set sha256 = "870ac9f461ebcc9514d861385787ac4be84636ab2b1eba3b91e096ad4d9c59c2" %}
+{% set name = "scikit-rf" %}
+{% set version = "1.8.0" %}
 
 package:
-  name: scikit-rf
+  name: {{ name }}
   version: {{ version }}
 
-
 source:
-  fn: scikit-rf-{{ version }}.tar.gz
-  # For some reason, 0.17.0 dropped the `.0` patch component from its GitHub
-  # archive names, so we need to munge the version string to avoid getting a
-  # 404 when downloading the sources.  Note that conda-forge set its conda
-  # package version to "0.17", but we are not doing that for defaults because
-  # we want our conda package's version string to match the version string the
-  # upstream authors published to PyPI.
-  url: https://github.com/scikit-rf/scikit-rf/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: c00ba602bf45ff3b368ccbb1ca93cbf0e18d0d5dfcff2591e0efacdff6d65a43
 
 build:
-  # Upstream has seemingly not put any effort into fixing the broken C
-  # components in `skrf.src`, so we may as well turn treat this as a pure
-  # Python package like conda-forge has done since v0.14.9.
-  skip: True  # [py<38]
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<38]
 
 requirements:
   host:
     - python
     - pip
     - wheel
-    - setuptools
+    - setuptools >=64
   run:
     - python
-    - pandas >=1.1
-    - numpy >=1.2.1
+    - numpy >=1.21
     - scipy >=1.7
+    - pandas >=1.1
+    - typing-extensions
+  run_constrained:
+    # testspice
+    - pyspice >=1.5
+    # plot
+    - matplotlib-base >=3.5
+    # xlsx 
+    - openpyxl >=3.0
+    # netw 
+    - networkx >=2.0
+    # visa
+    - pyvisa >=1.12
+    - pyvisa-py >=0.6
 
+# >   with pytest.raises(RuntimeWarning):
+# E   Failed: DID NOT RAISE <class 'RuntimeWarning'>
+# The test uses pytest.raises(RuntimeWarning) but warnings aren't exceptions—they need pytest.warns() instead.
+{% set deselect_tests = " --deselect=skrf/tests/test_network.py::NetworkTestCase" %}
 test:
+  source_files:
+    - skrf/tests
+    - skrf/io/tests
+    - doc
   imports:
     - skrf
     - skrf.calibration
     - skrf.data
     - skrf.io
     - skrf.media
-  requires:
-    - pip
   commands:
     - pip check
+    - pytest -v skrf {{ deselect_tests }}
+  requires:
+    - pip
+    - pytest >=7.0
+    - pytest-mock >=3.10
 
 about:
-  home: https://scikit-rf.org/
+  home: https://scikit-rf.org
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD
-  summary: 'Object Oriented Microwave Engineering.'
-  doc_url: https://scikit-rf.readthedocs.io/
+  summary: Object Oriented Microwave Engineering.
+  doc_url: https://scikit-rf.readthedocs.io
   description: |
     scikit-rf is an Open Source, BSD-licensed package for RF/Microwave
     engineering implemented in the Python programming language. It provides


### PR DESCRIPTION
scikit-rf 1.8.0 

**Destination channel:** Defaults

### Links

- [PKG-10469]
- dev_url:        https://github.com/scikit-rf/scikit-rf/tree/v1.8.0
- conda_forge:    https://github.com/conda-forge/scikit-rf-feedstock
- pypi:           https://pypi.org/project/scikit-rf/1.8.0
- pypi inspector: https://inspector.pypi.io/project/scikit-rf/1.8.0

### Explanation of changes:

- new version number


[PKG-10469]: https://anaconda.atlassian.net/browse/PKG-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ